### PR TITLE
<doc>:刷新本地服务列表instance个数一直是1的问题，导致无法进行负载均衡

### DIFF
--- a/server/registry_refresh.go
+++ b/server/registry_refresh.go
@@ -64,17 +64,13 @@ func groupByService(instances []*discovery.InstanceInfo) *sync.Map {
 		infosGeneric, exist := servMap.Load(ins.ServiceName)
 		if !exist {
 			infosGeneric = make([]*discovery.InstanceInfo, 0, 5)
-			infos, _ := infosGeneric.([]*discovery.InstanceInfo)
-			infos = append(infos, ins)
-
-			servMap.Store(ins.ServiceName, infos)
+			infosGeneric = append(infosGeneric.([]*discovery.InstanceInfo), ins)
 
 		} else {
-			infos, _ := infosGeneric.([]*discovery.InstanceInfo)
-			infos = append(infos, ins)
+			infosGeneric = append(infosGeneric.([]*discovery.InstanceInfo), ins)
 		}
+		servMap.Store(ins.ServiceName, infosGeneric)
 	}
-
 	return servMap
 }
 


### PR DESCRIPTION
append slice之后生成新的slice和servmap对应的value不是同一个slice

Issue #3
Close #3